### PR TITLE
Add Docker support for running gf

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+  backend:
+    build:
+      context: docker
+    ports:
+      - 8000:8000
+    volumes:
+      - .:/go/src/app
+    working_dir: /go/src/app
+    command: ["gf", "run", "main.go"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:1.21-bullseye
+
+RUN wget -O gf "https://github.com/gogf/gf/releases/latest/download/gf_$(go env GOOS)_$(go env GOARCH)" && chmod +x gf && ./gf install -y && rm ./gf


### PR DESCRIPTION
This pull request adds Docker support for running the gf (GoFrame) framework. It includes a Dockerfile that installs the necessary dependencies and sets up the working directory and command to run the main.go file. This allows developers to easily run the gf framework in a Docker container.